### PR TITLE
fix: judgement and newline order corruption in multithreading

### DIFF
--- a/judge.py
+++ b/judge.py
@@ -193,8 +193,7 @@ def main(args, config:Config):
         doc["score"] = judge.score
 
         with open(save_file, "a") as f:
-            f.write(json.dumps(doc, ensure_ascii=False))
-            f.write('\n')
+            f.write(json.dumps(doc, ensure_ascii=False) + '\n')
             f.close()
 
     if args.parallel == 1:


### PR DESCRIPTION
In judge.py, when multiple workers are set up, the output can sometimes be written out of order.
```
f.write(json.dumps(doc, ensure_ascii=False))
f.write('\n')
```
Specifically, when the judgement is written to the file in two separate f.write() operations, there's a chance that the content and the newline character (\n) may not be written sequentially.